### PR TITLE
Add `critical-section` feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ portable-atomic = { version = "1.5.1" }
 
 [features]
 nightly = []
+critical-section = ["portable-atomic/critical-section"]
 
 [package.metadata.docs.rs]
 features = ["nightly"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/embassy-rs/static-cell"
 
 [dependencies]
-portable-atomic = { version = "1.5.1" }
+portable-atomic = "1.6.0"
 
 [features]
 nightly = []


### PR DESCRIPTION
Since `static_cell` 2.0.0, you had to add an additional dependency on `portable-atomic` to enable the `critical-section` feature flag. This PR removes that requirement, and instead lets you use the feature flag right on `static_cell` itself.