### PR TITLE
fix: remove unneded `unsafe` block`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -238,7 +238,7 @@ macro_rules! make_static {
         $(#[$m])*
         static STATIC_CELL: $crate::StaticCell<T> = $crate::StaticCell::new();
         #[deny(unused_attributes)]
-        let (x,) = unsafe { STATIC_CELL.uninit().write(($val,)) };
+        let (x,) = STATIC_CELL.uninit().write(($val,));
         x
     }};
 }


### PR DESCRIPTION
Hello, `MaybeUninit::write` and `StaticCell::uninit` are both safe, so there is no need in `unsafe` block